### PR TITLE
Improve path handling a little

### DIFF
--- a/src/com/vincent64/mcchathistory/Settings.java
+++ b/src/com/vincent64/mcchathistory/Settings.java
@@ -1,10 +1,11 @@
 package com.vincent64.mcchathistory;
 
+import com.vincent64.mcchathistory.util.OS;
+import com.vincent64.mcchathistory.util.PathHelper;
+import java.nio.file.Path;
 import java.util.prefs.Preferences;
 
 public class Settings {
-    private static final String APPDATA_PATH_WINDOWS = "\\AppData\\Roaming\\";
-    private static final String APPDATA_PATH_MACOS = "/Library/Application Support/";
     private static final String PATH_KEY = "mcch_path";
     private static Preferences preferences;
     private static String path;
@@ -13,17 +14,9 @@ public class Settings {
         //Load preferences
         preferences = Preferences.userRoot();
 
-        //Detect operating system
-        String os = System.getProperty("os.name").toLowerCase();
-        //Get default path for Windows
-        String defaultPath = System.getProperty("user.home") + APPDATA_PATH_WINDOWS + ".minecraft\\logs";
-        //Get default path for macOS
-        if(os.contains("mac")) {
-            defaultPath = System.getProperty("user.home") + APPDATA_PATH_MACOS + "minecraft/logs";
-        }
-
         //Get preferences
-        path = preferences.get(PATH_KEY, defaultPath);
+        Path logsPath = PathHelper.getDefaultMinecraftPath().resolve("logs");
+        path = preferences.get(PATH_KEY, logsPath.toString());
     }
 
     public static void setPath(String path) {

--- a/src/com/vincent64/mcchathistory/util/OS.java
+++ b/src/com/vincent64/mcchathistory/util/OS.java
@@ -1,0 +1,22 @@
+package com.vincent64.mcchathistory.util;
+
+public static enum OS {
+    WINDOWS,
+    OSX,
+    NIX,
+    UNKNOWN;
+
+    public static OS getCurrent() {
+        String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+		if (string.contains("win")) {
+			return WINDOWS;
+		} else if (string.contains("mac")) {
+			return OSX;
+		} else if (string.contains("linux") || string.contains("unix") || string.contains("solaris") || string.contains("sunos")) {
+			return NIX;
+        } else {
+            return UNKNOWN;
+		}
+
+    }
+}

--- a/src/com/vincent64/mcchathistory/util/PathHelper.java
+++ b/src/com/vincent64/mcchathistory/util/PathHelper.java
@@ -1,0 +1,43 @@
+package com.vincent64.mcchathistory.util;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public static class PathHelper {
+    
+    private static final OS os = OS.getCurrent();
+
+    public static Path getDefaultMinecraftPath() {
+        switch (os) {
+            case WINDOWS:
+			    return Paths.get(System.getenv("APPDATA"), ".minecraft").toAbsolutePath();
+            case OSX:
+                return Paths.get(System.getProperty("user.home"), "Library", "Application Support", "minecraft").toAbsolutePath();
+            case NIX:
+                return Paths.get(System.getProperty("user.home"), ".minecraft").toAbsolutePath();
+            default:
+                // Use current working directory by default on unknown operating systems
+                return Paths.get("minecraft").toAbsolutePath();
+        }
+    }
+
+    public static Path getMCCHRootDirectory() {
+        switch (os) {
+            case WINDOWS:
+			    return Paths.get(System.getenv("APPDATA"), "MinecraftChatHistory").toAbsolutePath();
+            case OSX:
+                return Paths.get(System.getProperty("user.home"), "Library", "Application Support", "MinecraftChatHistory").toAbsolutePath();
+            case NIX: {
+                // For *nix systems, we should follow XDG
+                String dataHome = System.getenv("XDG_DATA_HOME");
+                if (dataHome != null) {
+                    return Paths.get(dataHome, "MinecraftChatHistory").toAbsolutePath();
+                }
+                return Paths.get(System.getProperty("user.home"), ".local", "share", "MinecraftChatHistory").toAbsolutePath();
+            }
+            default:
+                // Use current working directory by default on unknown operating systems
+                return Paths.get("MinecraftChatHistory").toAbsolutePath();
+        }
+    }
+}

--- a/src/com/vincent64/mcchatsearch/Settings.java
+++ b/src/com/vincent64/mcchatsearch/Settings.java
@@ -12,8 +12,7 @@ public class Settings {
     private static final String PATH_KEY = "mccs_path";
     private static Preferences preferences;
     private static String path;
-    private static String os;
-
+    
     static {
         //Load preferences
         preferences = Preferences.userRoot();

--- a/src/com/vincent64/mcchatsearch/Settings.java
+++ b/src/com/vincent64/mcchatsearch/Settings.java
@@ -1,23 +1,14 @@
 package com.vincent64.mcchatsearch;
 
+import com.vincent64.mcchathistory.util.OS;
+import com.vincent64.mcchathistory.util.PathHelper;
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.Files;
 import java.util.prefs.Preferences;
 
 public class Settings {
-    private static final String APPDATA_PATH_WINDOWS = "\\AppData\\Roaming\\";
-    private static final String APPDATA_PATH_MACOS = "/Library/Application Support/";
-    private static final String PATH_MCCH_WINDOWS =
-            APPDATA_PATH_WINDOWS + "MinecraftChatHistory\\MinecraftChatHistory\\MCCH.jar";
-    private static final String PATH_MCCH_MACOS =
-            APPDATA_PATH_MACOS + "MinecraftChatHistory/MinecraftChatHistory/MCCH.jar";
-    private static final String PATH_EXTRACTED_LOGS_WINDOWS =
-            APPDATA_PATH_WINDOWS + "MinecraftChatHistory\\MinecraftChatSearch\\ExtractedLogs\\";
-    private static final String PATH_EXTRACTED_LOGS_MACOS =
-            APPDATA_PATH_MACOS + "MinecraftChatHistory/MinecraftChatSearch/ExtractedLogs/";
-    private static final String PATH_SAVED_RESULTS_WINDOWS =
-            APPDATA_PATH_WINDOWS + "MinecraftChatHistory\\MinecraftChatSearch\\SavedResults\\";
-    private static final String PATH_SAVED_RESULTS_MACOS =
-            APPDATA_PATH_MACOS + "MinecraftChatHistory/MinecraftChatSearch/SavedResults/";
     private static final String PATH_KEY = "mccs_path";
     private static Preferences preferences;
     private static String path;
@@ -27,17 +18,9 @@ public class Settings {
         //Load preferences
         preferences = Preferences.userRoot();
 
-        //Detect operating system
-        os = System.getProperty("os.name").toLowerCase();
-        //Get default path for Windows
-        String defaultPath = System.getProperty("user.home") + APPDATA_PATH_WINDOWS + ".minecraft\\logs";
-        //Get default path for macOS
-        if(os.contains("mac")) {
-            defaultPath = System.getProperty("user.home") + APPDATA_PATH_MACOS + "minecraft/logs";
-        }
-
         //Get preferences
-        path = preferences.get(PATH_KEY, defaultPath);
+        Path logsPath = PathHelper.getDefaultMinecraftPath().resolve("logs");
+        path = preferences.get(PATH_KEY, logsPath.toString());
     }
 
     public static void setPath(String path) {
@@ -50,41 +33,18 @@ public class Settings {
     }
 
     public static String getMCCHPath() {
-        //Get MCCH path for Windows
-        String path = System.getProperty("user.home") + PATH_MCCH_WINDOWS;
-        //Get MCCH path for macOS
-        if(os.contains("mac")) {
-            path = System.getProperty("user.home") + PATH_MCCH_MACOS;
-        }
-
-        return path;
+        return PathHelper.getMCCHRootDirectory().resolve("MinecraftChatHistory").resolve("MCCH.jar").toString();
     }
 
     public static String getExtractedLogsPath() {
-        //Get extracted log path for Windows
-        String path = System.getProperty("user.home") + PATH_EXTRACTED_LOGS_WINDOWS;
-        //Get extracted log path for macOS
-        if(os.contains("mac")) {
-            path = System.getProperty("user.home") + PATH_EXTRACTED_LOGS_MACOS;
-        }
-
-        File file = new File(path);
-        //Create folder if they don't exist
-        if(!file.exists()) file.mkdirs();
-        return path;
+        Path path = PathHelper.getMCCHRootDirectory().resolve("MinecraftChatSearch").resolve("ExtractedLogs");
+        Files.createDirectories(path);
+        return path.toString();
     }
 
     public static String getSavedResultsPath() {
-        //Get saved results path for Windows
-        String path = System.getProperty("user.home") + PATH_SAVED_RESULTS_WINDOWS;
-        //Get saved results path for macOS
-        if(os.contains("mac")) {
-            path = System.getProperty("user.home") + PATH_SAVED_RESULTS_MACOS;
-        }
-
-        File file = new File(path);
-        //Create folder if they don't exist
-        if(!file.exists()) file.mkdirs();
-        return path;
+        Path path = PathHelper.getMCCHRootDirectory().resolve("MinecraftChatSearch").resolve("SavedResults");
+        Files.createDirectories(path);
+        return path.toString();
     }
 }

--- a/src/com/vincent64/mcchatsearch/util/OS.java
+++ b/src/com/vincent64/mcchatsearch/util/OS.java
@@ -1,0 +1,22 @@
+package com.vincent64.mcchatsearch.util;
+
+public static enum OS {
+    WINDOWS,
+    OSX,
+    NIX,
+    UNKNOWN;
+
+    public static OS getCurrent() {
+        String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+		if (string.contains("win")) {
+			return WINDOWS;
+		} else if (string.contains("mac")) {
+			return OSX;
+		} else if (string.contains("linux") || string.contains("unix") || string.contains("solaris") || string.contains("sunos")) {
+			return NIX;
+        } else {
+            return UNKNOWN;
+		}
+
+    }
+}

--- a/src/com/vincent64/mcchatsearch/util/PathHelper.java
+++ b/src/com/vincent64/mcchatsearch/util/PathHelper.java
@@ -1,0 +1,43 @@
+package com.vincent64.mcchatsearch.util;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public static class PathHelper {
+    
+    private static final OS os = OS.getCurrent();
+
+    public static Path getDefaultMinecraftPath() {
+        switch (os) {
+            case WINDOWS:
+			    return Paths.get(System.getenv("APPDATA"), ".minecraft").toAbsolutePath();
+            case OSX:
+                return Paths.get(System.getProperty("user.home"), "Library", "Application Support", "minecraft").toAbsolutePath();
+            case NIX:
+                return Paths.get(System.getProperty("user.home"), ".minecraft").toAbsolutePath();
+            default:
+                // Use current working directory by default on unknown operating systems
+                return Paths.get("minecraft").toAbsolutePath();
+        }
+    }
+
+    public static Path getMCCHRootDirectory() {
+        switch (os) {
+            case WINDOWS:
+			    return Paths.get(System.getenv("APPDATA"), "MinecraftChatHistory").toAbsolutePath();
+            case OSX:
+                return Paths.get(System.getProperty("user.home"), "Library", "Application Support", "MinecraftChatHistory").toAbsolutePath();
+            case NIX: {
+                // For *nix systems, we should follow XDG
+                String dataHome = System.getenv("XDG_DATA_HOME");
+                if (dataHome != null) {
+                    return Paths.get(dataHome, "MinecraftChatHistory").toAbsolutePath();
+                }
+                return Paths.get(System.getProperty("user.home"), ".local", "share", "MinecraftChatHistory").toAbsolutePath();
+            }
+            default:
+                // Use current working directory by default on unknown operating systems
+                return Paths.get("MinecraftChatHistory").toAbsolutePath();
+        }
+    }
+}


### PR DESCRIPTION
This cleans up handling paths by using the NIO Path API rather than directly building strings. It also handles other operating systems properly by not just assuming it's Windows if it's not OSX. I have no idea if the project even works on other operating systems, even with these changes, but it's an improvement nonetheless.

I tried to avoid changing too much but I did clean up the many versions of the path fields.

FYI: I haven't actually tested it as you have a non-standard build environment.
This is also why I simply duplicated PathHelper.java and OS.java into both packages rather than share a common module.